### PR TITLE
Fix for missing match data and remove unused build file

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -1,1 +1,0 @@
-g++ -std=c++17 -I/usr/include/postgresql src/main.cpp src/riot_api.cpp src/db.cpp src/summary.cpp -o main -lpq

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,10 +70,19 @@ int main() {
         matchIds.push_back(gid);
     }
 
+    if (matchIds.empty()) {
+        std::cerr << "No match IDs retrieved. Check your network connection or API key." << std::endl;
+        return 1;
+    }
+
     std::vector<MatchSummary> matches;
     for (const auto &id : matchIds) {
         std::cout << "Downloading match " << id << "\n";
         std::string json = riot::get_match(id, apiKey, routing);
+        if (json.empty()) {
+            std::cerr << "Failed to download match " << id << "\n";
+            continue;
+        }
         matches.push_back(parse_match_json(json, id));
     }
 


### PR DESCRIPTION
## Summary
- remove obsolete `build.txt`
- improve `src/main.cpp` to detect failed API calls and print helpful error messages

## Testing
- `make clean && make`
- `./main <<EOF
3
n
EOF` *(fails to get PUUID due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_68776a758060832d821fa752bfac3aec