### PR TITLE
Use Summoner-V4 for PUUID and add verbose mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,15 +51,15 @@ int main() {
     const std::string region = "euw1";
     const std::string routing = "europe";
     const std::string summoner = "MoonFloww";
-    const std::string tag = "1188";
 
     if (!riot::api_key_valid(apiKey)) {
         std::cerr << "Invalid Riot API key." << std::endl;
         return 1;
     }
 
+    riot::set_verbose(true);
     std::cout << "Fetching PUUID...\n";
-    std::string puuid = riot::get_puuid(summoner, tag, apiKey, routing);
+    std::string puuid = riot::get_puuid(summoner, apiKey, region);
     if (puuid.empty()) {
         std::cerr << "Failed to get PUUID\n";
         return 1;

--- a/src/riot_api.h
+++ b/src/riot_api.h
@@ -6,10 +6,10 @@
 
 namespace riot {
 bool api_key_valid(const std::string &apiKey);
-std::string get_puuid(const std::string &gameName,
-                      const std::string &tagLine,
+void set_verbose(bool v);
+std::string get_puuid(const std::string &summonerName,
                       const std::string &apiKey,
-                      const std::string &routing);
+                      const std::string &region);
 std::vector<std::string> get_match_ids(const std::string &puuid,
                                        int count,
                                        const std::string &apiKey,


### PR DESCRIPTION
- add optional verbose output in `riot_api`
- switch PUUID lookup to Summoner-V4 endpoint
- expose `set_verbose` and call it from `main`
- update calls to new `get_puuid` API